### PR TITLE
Fix incorrect class references

### DIFF
--- a/sheldon-impl/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/sheldon-impl/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,1 +1,1 @@
-org.tomitribe.crest.connector.cdi.TerminalSessionExtension
+org.tomitribe.sheldon.cdi.TerminalSessionExtension

--- a/sheldon-rar/src/main/rar/META-INF/ra.xml
+++ b/sheldon-rar/src/main/rar/META-INF/ra.xml
@@ -41,7 +41,7 @@
 		<inbound-resourceadapter>
 			<messageadapter>
 				<messagelistener>
-					<messagelistener-type>org.tomitribe.crest.connector.api.CommandListener</messagelistener-type>
+					<messagelistener-type>org.tomitribe.sheldon.api.CommandListener</messagelistener-type>
 					<activationspec>
 						<activationspec-class>org.tomitribe.sheldon.adapter.CommandActivationSpec</activationspec-class>
 					</activationspec>


### PR DESCRIPTION
Fixing a couple of class references hanging over from project rename
